### PR TITLE
Fixed incorrect path

### DIFF
--- a/includes/auth_handler.py
+++ b/includes/auth_handler.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         print "[!] No options supplied. Try --help."
     else:
 
-        auth_ = auth('sqlite:////root/snoopy_api/snoopy.db')
+        auth_ = auth('sqlite:////root/snoopy.db')
         if args.assoc:
             usr,drn = args.assoc.split(",")
             print "[+] Associating user '%s' to drone '%s'" %(usr,drn)


### PR DESCRIPTION
Fixed error added in last commit which prevented creating new Drones.

auth_ = auth('sqlite:////root/snoopy_api/snoopy.db')
should be:
auth_ = auth('sqlite:////root/snoopy.db')
